### PR TITLE
Migrate to standalone `pkcs12`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 // indirect
 	golang.org/x/text v0.3.4 // indirect
 	golang.org/x/tools v0.0.0-20201204162204-73cf035baebf // indirect
-	gopkg.in/DataDog/dd-trace-go.v1 v1.27.1
+	gopkg.in/DataDog/dd-trace-go.v1 v1.27.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	howett.net/plist v0.0.0-20171105004507-233df3c4f07b // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/DataDog/datadog-go v4.2.0+incompatible // indirect
 	github.com/agext/levenshtein v1.2.3 // indirect
 	github.com/bitrise-io/go-utils v0.0.0-20171018094958-961320f9011c
+	github.com/bitrise-io/pkcs12 v0.0.0-20210430063833-0da06eb56630
 	github.com/bitrise-tools/go-xcode v0.0.0-20190228101802-b3f7172f9106
 	github.com/bmatcuk/doublestar v1.3.4 // indirect
 	github.com/fullsailor/pkcs7 v0.0.0-20170613201221-a009d8d7de53 // indirect
@@ -36,7 +37,7 @@ require (
 	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 // indirect
 	golang.org/x/text v0.3.4 // indirect
 	golang.org/x/tools v0.0.0-20201204162204-73cf035baebf // indirect
-	gopkg.in/DataDog/dd-trace-go.v1 v1.27.1 // indirect
+	gopkg.in/DataDog/dd-trace-go.v1 v1.27.1
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	howett.net/plist v0.0.0-20171105004507-233df3c4f07b // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -969,7 +969,6 @@ gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/go.sum
+++ b/go.sum
@@ -117,6 +117,8 @@ github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bitrise-io/go-utils v0.0.0-20171018094958-961320f9011c h1:ZAbfZ/6AnrKppmOU4NR+cxME1ArVw1vGyxgR7ndcWqE=
 github.com/bitrise-io/go-utils v0.0.0-20171018094958-961320f9011c/go.mod h1:Pp48eQd8BSNEzWWTBxdFUd/ufS5b5Bgkmt9D5NedjWg=
+github.com/bitrise-io/pkcs12 v0.0.0-20210430063833-0da06eb56630 h1:V+xoYqGSkN8aUxCc806zDKjGGpBVUtV0Vytf5OsB3gc=
+github.com/bitrise-io/pkcs12 v0.0.0-20210430063833-0da06eb56630/go.mod h1:UiXKNs0essbC14a2TvGlnUKo9isP9m4guPrp8KJHJpU=
 github.com/bitrise-tools/go-xcode v0.0.0-20190228101802-b3f7172f9106 h1:JgD65YvkX3161ieU5q0XzUrbr2kO9id2MdPFjuUkGUs=
 github.com/bitrise-tools/go-xcode v0.0.0-20190228101802-b3f7172f9106/go.mod h1:PL/0GBjJb03cyJAh1sN0CrJe0y7dXzDW3O5m03CvM7Q=
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
@@ -967,6 +969,7 @@ gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/main.go
+++ b/main.go
@@ -85,7 +85,7 @@ func profileToJSON(profile []byte) (string, error) {
 
 func certificateToJSON(p12, key []byte) (string, error) {
 	sKey := strings.TrimSuffix(string(key), "\n")
-	certs, err := pkcs12.DecodeAllCerts(p12, "sKey")
+	certs, _, err := pkcs12.DecodeAll(p12, sKey)
 	if err != nil {
 		return "", err
 	}

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/bitrise-io/go-utils/pkcs12"
+	"github.com/bitrise-io/pkcs12"
 	"github.com/bitrise-tools/go-xcode/certificateutil"
 	"github.com/bitrise-tools/go-xcode/profileutil"
 	"gopkg.in/DataDog/dd-trace-go.v1/contrib/gorilla/mux"
@@ -85,7 +85,7 @@ func profileToJSON(profile []byte) (string, error) {
 
 func certificateToJSON(p12, key []byte) (string, error) {
 	sKey := strings.TrimSuffix(string(key), "\n")
-	certs, err := pkcs12.DecodeAllCerts(p12, sKey)
+	certs, err := pkcs12.DecodeAllCerts(p12, "sKey")
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
https://bitrise.atlassian.net/browse/STEP-815

### Context
Previously `go-utils` contained the `pkcs12` package. We decided in the Steps Toolkit initiative to extract it into a separate repository. This repository depends on it, so it is needed to be migrated to the standalone one.

Changes
- the repository now depends on the standalone `pkcs12`