### PR TITLE
Fix go build command

### DIFF
--- a/Dockerfile.internal-platform
+++ b/Dockerfile.internal-platform
@@ -6,7 +6,7 @@ WORKDIR build
 
 COPY . .
 
-RUN go build -o /go-app main.go
+RUN go build -o /go-app ./...
 
 
 FROM alpine:3.17


### PR DESCRIPTION
This PR updates the go build command used for deploying the service.

This is needed because, in the [last PR](https://github.com/bitrise-io/identity-info-server/pull/19) the source code was split into multiple go files, and the build command was failing:

```
#6 [builder 4/4] RUN go build -o /go-app main.go
#6 sha256:ff4f584012d64d404d047931e8ea9bc12786ef4505afba05ed292c4277f7216b
#6 10.47 # command-line-arguments
#6 10.47 ./main.go:19:36: undefined: handleCertificate
#6 10.47 ./main.go:20:32: undefined: handleProfile
#6 10.47 ./main.go:21:33: undefined: handleKeystore
#6 10.47 ./main.go:25:3: undefined: logCritical
#6 10.47 ./main.go:40:3: undefined: logCritical
#6 ERROR: process "/bin/sh -c go build -o /go-app main.go" did not complete successfully: exit code: 1
```