### PR TITLE
Add content metadata fields to code signing extraction endpoints

### DIFF
--- a/certificate.go
+++ b/certificate.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -23,12 +22,6 @@ type CertificateInfoModel struct {
 	ListingType     CertificateListingType     `json:"ListingType"`
 	ListingPlatform CertificateListingPlatform `json:"ListingPlatform"`
 
-	// CertificateSerial is the X.509 serial number as uppercase hexadecimal (e.g. "0A1B2C3D4E5F6071").
-	// It is null when the serial number cannot be determined.
-	CertificateSerial *string `json:"certificate_serial"`
-	// CertificateExpiryDate is the certificate notAfter date in RFC 3339 / ISO 8601 UTC.
-	// It is null when the expiry date cannot be determined.
-	CertificateExpiryDate *time.Time `json:"certificate_expiry_date"`
 	// FileSHA256 is the SHA-256 of the uploaded file bytes as lowercase hex.
 	// It is null for certificates that are not backed by an uploaded file (e.g. certificates
 	// embedded in a provisioning profile).
@@ -95,7 +88,7 @@ func (s Service) certsToCertModels(certs []certificateutil.CertificateInfoModel,
 			}
 		}
 
-		model := CertificateInfoModel{
+		certModels = append(certModels, CertificateInfoModel{
 			CommonName:      cert.CommonName,
 			TeamName:        cert.TeamName,
 			TeamID:          cert.TeamID,
@@ -105,19 +98,7 @@ func (s Service) certsToCertModels(certs []certificateutil.CertificateInfoModel,
 			ListingType:     listingType,
 			ListingPlatform: listingPlatform,
 			FileSHA256:      fileSHA256,
-		}
-
-		if cert.Certificate.SerialNumber != nil {
-			serialHex := strings.ToUpper(hex.EncodeToString(cert.Certificate.SerialNumber.Bytes()))
-			model.CertificateSerial = &serialHex
-		}
-
-		if !cert.Certificate.NotAfter.IsZero() {
-			expiry := cert.Certificate.NotAfter.UTC()
-			model.CertificateExpiryDate = &expiry
-		}
-
-		certModels = append(certModels, model)
+		})
 	}
 	return certModels
 }

--- a/certificate.go
+++ b/certificate.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -21,6 +22,17 @@ type CertificateInfoModel struct {
 	StartDate       time.Time                  `json:"StartDate"`
 	ListingType     CertificateListingType     `json:"ListingType"`
 	ListingPlatform CertificateListingPlatform `json:"ListingPlatform"`
+
+	// CertificateSerial is the X.509 serial number as uppercase hexadecimal (e.g. "0A1B2C3D4E5F6071").
+	// It is null when the serial number cannot be determined.
+	CertificateSerial *string `json:"certificate_serial"`
+	// CertificateExpiryDate is the certificate notAfter date in RFC 3339 / ISO 8601 UTC.
+	// It is null when the expiry date cannot be determined.
+	CertificateExpiryDate *time.Time `json:"certificate_expiry_date"`
+	// FileSHA256 is the SHA-256 of the uploaded file bytes as lowercase hex.
+	// It is null for certificates that are not backed by an uploaded file (e.g. certificates
+	// embedded in a provisioning profile).
+	FileSHA256 *string `json:"file_sha256"`
 }
 
 // HandleCertificate ...
@@ -54,7 +66,8 @@ func (s Service) certificateToJSON(data []byte, password string) (string, error)
 		return "", err
 	}
 
-	certModels := s.certsToCertModels(certs)
+	fileSHA256 := sha256Hex(data)
+	certModels := s.certsToCertModels(certs, &fileSHA256)
 	b, err := json.Marshal(certModels)
 	if err != nil {
 		return "", err
@@ -63,7 +76,10 @@ func (s Service) certificateToJSON(data []byte, password string) (string, error)
 	return string(b), nil
 }
 
-func (s Service) certsToCertModels(certs []certificateutil.CertificateInfoModel) []CertificateInfoModel {
+// certsToCertModels maps the parsed certificates to response models.
+// fileSHA256 is the SHA-256 of the uploaded file the certificates were extracted from; pass nil
+// for certificates that do not originate from an uploaded file (e.g. profile-embedded certificates).
+func (s Service) certsToCertModels(certs []certificateutil.CertificateInfoModel, fileSHA256 *string) []CertificateInfoModel {
 	var certModels []CertificateInfoModel
 	for _, cert := range certs {
 		listingType := UnknownCertificateListingType
@@ -79,7 +95,7 @@ func (s Service) certsToCertModels(certs []certificateutil.CertificateInfoModel)
 			}
 		}
 
-		certModels = append(certModels, CertificateInfoModel{
+		model := CertificateInfoModel{
 			CommonName:      cert.CommonName,
 			TeamName:        cert.TeamName,
 			TeamID:          cert.TeamID,
@@ -88,7 +104,20 @@ func (s Service) certsToCertModels(certs []certificateutil.CertificateInfoModel)
 			Serial:          cert.Serial,
 			ListingType:     listingType,
 			ListingPlatform: listingPlatform,
-		})
+			FileSHA256:      fileSHA256,
+		}
+
+		if cert.Certificate.SerialNumber != nil {
+			serialHex := strings.ToUpper(hex.EncodeToString(cert.Certificate.SerialNumber.Bytes()))
+			model.CertificateSerial = &serialHex
+		}
+
+		if !cert.Certificate.NotAfter.IsZero() {
+			expiry := cert.Certificate.NotAfter.UTC()
+			model.CertificateExpiryDate = &expiry
+		}
+
+		certModels = append(certModels, model)
 	}
 	return certModels
 }

--- a/certificate_test.go
+++ b/certificate_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/json"
 	"io"
 	"math/big"
@@ -14,6 +15,58 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
+
+func Test_certsToCertModels_contentMetadata(t *testing.T) {
+	notAfter := time.Date(2027, 5, 28, 0, 0, 0, 0, time.UTC)
+	// Serial bytes 0x0A1B2C3D4E5F6071 must render as uppercase, byte-aligned hex.
+	serial := new(big.Int).SetBytes([]byte{0x0A, 0x1B, 0x2C, 0x3D, 0x4E, 0x5F, 0x60, 0x71})
+
+	x509Cert := x509.Certificate{
+		Subject:      pkix.Name{CommonName: "Apple Development: Test User (ABCDE12345)"},
+		NotBefore:    notAfter.Add(-24 * time.Hour),
+		NotAfter:     notAfter,
+		SerialNumber: serial,
+	}
+	cert := certificateutil.NewCertificateInfo(x509Cert, nil)
+
+	fileHash := "0123456789abcdef"
+	s := Service{Logger: log.New()}
+	models := s.certsToCertModels([]certificateutil.CertificateInfoModel{cert}, &fileHash)
+	require.Len(t, models, 1)
+	model := models[0]
+
+	require.NotNil(t, model.CertificateSerial)
+	require.Equal(t, "0A1B2C3D4E5F6071", *model.CertificateSerial)
+
+	require.NotNil(t, model.CertificateExpiryDate)
+	require.Equal(t, notAfter, *model.CertificateExpiryDate)
+
+	require.NotNil(t, model.FileSHA256)
+	require.Equal(t, fileHash, *model.FileSHA256)
+
+	// The existing decimal Serial field must be preserved alongside the new hex field.
+	require.Equal(t, serial.String(), model.Serial)
+}
+
+func Test_certsToCertModels_nilFileSHA256(t *testing.T) {
+	// Certificates embedded in a profile have no backing uploaded file.
+	x509Cert := x509.Certificate{
+		Subject:      pkix.Name{CommonName: "Apple Development: Test User (ABCDE12345)"},
+		NotAfter:     time.Date(2027, 5, 28, 0, 0, 0, 0, time.UTC),
+		SerialNumber: big.NewInt(42),
+	}
+	cert := certificateutil.NewCertificateInfo(x509Cert, nil)
+
+	s := Service{Logger: log.New()}
+	models := s.certsToCertModels([]certificateutil.CertificateInfoModel{cert}, nil)
+	require.Len(t, models, 1)
+
+	require.Nil(t, models[0].FileSHA256)
+	// Serial and expiry are intrinsic to the certificate and still populated.
+	require.NotNil(t, models[0].CertificateSerial)
+	require.Equal(t, "2A", *models[0].CertificateSerial)
+	require.NotNil(t, models[0].CertificateExpiryDate)
+}
 
 func Test_certsToCertModels(t *testing.T) {
 	tests := []struct {
@@ -97,7 +150,7 @@ func Test_certsToCertModels(t *testing.T) {
 			x509Cert := newCertFromJSON(t, f)
 			cert := certificateutil.NewCertificateInfo(*x509Cert, nil)
 			s := Service{Logger: log.New()}
-			certModels := s.certsToCertModels([]certificateutil.CertificateInfoModel{cert})
+			certModels := s.certsToCertModels([]certificateutil.CertificateInfoModel{cert}, nil)
 			certModel := certModels[0]
 			require.Equal(t, tt.wantType, certModel.ListingType)
 			require.Equal(t, tt.wantPlatform, certModel.ListingPlatform)

--- a/certificate_test.go
+++ b/certificate_test.go
@@ -16,10 +16,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_certsToCertModels_contentMetadata(t *testing.T) {
+func Test_certsToCertModels_fileSHA256(t *testing.T) {
 	notAfter := time.Date(2027, 5, 28, 0, 0, 0, 0, time.UTC)
-	// Serial bytes 0x0A1B2C3D4E5F6071 must render as uppercase, byte-aligned hex.
-	serial := new(big.Int).SetBytes([]byte{0x0A, 0x1B, 0x2C, 0x3D, 0x4E, 0x5F, 0x60, 0x71})
+	serial := big.NewInt(42)
 
 	x509Cert := x509.Certificate{
 		Subject:      pkix.Name{CommonName: "Apple Development: Test User (ABCDE12345)"},
@@ -35,21 +34,17 @@ func Test_certsToCertModels_contentMetadata(t *testing.T) {
 	require.Len(t, models, 1)
 	model := models[0]
 
-	require.NotNil(t, model.CertificateSerial)
-	require.Equal(t, "0A1B2C3D4E5F6071", *model.CertificateSerial)
-
-	require.NotNil(t, model.CertificateExpiryDate)
-	require.Equal(t, notAfter, *model.CertificateExpiryDate)
-
 	require.NotNil(t, model.FileSHA256)
 	require.Equal(t, fileHash, *model.FileSHA256)
 
-	// The existing decimal Serial field must be preserved alongside the new hex field.
+	// The existing serial and expiry fields are preserved unchanged; consumers derive any
+	// alternative representation (e.g. hex serial) from these on the presentation side.
 	require.Equal(t, serial.String(), model.Serial)
+	require.Equal(t, notAfter, model.EndDate)
 }
 
 func Test_certsToCertModels_nilFileSHA256(t *testing.T) {
-	// Certificates embedded in a profile have no backing uploaded file.
+	// Certificates embedded in a profile have no backing uploaded file, so file_sha256 is null.
 	x509Cert := x509.Certificate{
 		Subject:      pkix.Name{CommonName: "Apple Development: Test User (ABCDE12345)"},
 		NotAfter:     time.Date(2027, 5, 28, 0, 0, 0, 0, time.UTC),
@@ -62,10 +57,6 @@ func Test_certsToCertModels_nilFileSHA256(t *testing.T) {
 	require.Len(t, models, 1)
 
 	require.Nil(t, models[0].FileSHA256)
-	// Serial and expiry are intrinsic to the certificate and still populated.
-	require.NotNil(t, models[0].CertificateSerial)
-	require.Equal(t, "2A", *models[0].CertificateSerial)
-	require.NotNil(t, models[0].CertificateExpiryDate)
 }
 
 func Test_certsToCertModels(t *testing.T) {

--- a/keystore.go
+++ b/keystore.go
@@ -77,9 +77,9 @@ func keystoreToJSON(data []byte, password, alias, keyPassword string) (string, e
 	fileSHA256 := sha256Hex(data)
 	certModel.FileSHA256 = &fileSHA256
 
-	// The certificate fingerprint is best effort: ReadCertificateInformation does not expose the
-	// raw certificate, so we decode it again to compute the fingerprint. Decoding already succeeded
-	// above, so this should succeed too; if it does not, the fingerprint is left null.
+	// The certificate fingerprint is best effort. See keystoreSigningCertificate for why the
+	// keystore is decoded a second time here. Decoding already succeeded above, so this should
+	// succeed too; if it does not, the fingerprint is left null.
 	if cert, err := keystoreSigningCertificate(data, password, alias, keyPassword); err == nil {
 		fingerprint := sha256Fingerprint(cert)
 		certModel.CertificateSHA256Fingerprint = &fingerprint
@@ -93,8 +93,24 @@ func keystoreToJSON(data []byte, password, alias, keyPassword string) (string, e
 	return string(b), nil
 }
 
-// keystoreSigningCertificate decodes the keystore and returns the signing certificate.
-// It mirrors the decoders used by keystore.NewDefaultReader.
+// keystoreSigningCertificate decodes the keystore and returns the raw signing certificate so its
+// SHA-256 fingerprint can be computed.
+//
+// This is a known, deliberate workaround, flagged in code review:
+//
+// The fingerprint is a property of the exact certificate that keystore.Reader.ReadCertificateInformation
+// already decodes. That method, however, decodes the keystore, parses the *x509.Certificate into a
+// keystore.CertificateInformation and then discards the raw certificate, so the caller never gets it
+// back. The vendored keystore package exposes no lower-level Reader method that returns the raw
+// certificate. The only public way to obtain it is via the Decoder API, which forces us to both
+// re-declare the same decoder list that keystore.NewDefaultReader uses internally (there is no
+// accessor for a Reader's decoders) and decode the keystore a second time.
+//
+// The proper fix belongs upstream in go-android: ReadCertificateInformation should also return the
+// decoded *x509.Certificate (or the fingerprint), which would let us drop this function and the
+// duplicate decode entirely. That change is out of scope here because the dependency is vendored and
+// must not be modified in this repository. Until it lands, this pragmatic double-decode keeps the
+// fingerprint correct without touching existing keystore error handling.
 func keystoreSigningCertificate(data []byte, password, alias, keyPassword string) (*x509.Certificate, error) {
 	decoders := []keystore.Decoder{keystore.PKCS12KeystoreDecoder{}, keystore.JKSKeystoreDecoder{}}
 	for _, decoder := range decoders {

--- a/keystore.go
+++ b/keystore.go
@@ -1,9 +1,13 @@
 package main
 
 import (
+	"crypto/sha256"
+	"crypto/x509"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/bitrise-io/go-android/v2/keystore"
 )
@@ -18,6 +22,13 @@ type CertificateInformation struct {
 	CountryCode        string `json:"country_code,omitempty"`
 	ValidFrom          string `json:"valid_from,omitempty"`
 	ValidUntil         string `json:"valid_until,omitempty"`
+
+	// CertificateSHA256Fingerprint is the SHA-256 fingerprint of the signing certificate in keytool
+	// format: uppercase hex, colon-separated (e.g. "AB:CD:EF:..."). It is null when the fingerprint
+	// cannot be determined.
+	CertificateSHA256Fingerprint *string `json:"certificate_sha256_fingerprint"`
+	// FileSHA256 is the SHA-256 of the uploaded file bytes as lowercase hex.
+	FileSHA256 *string `json:"file_sha256"`
 }
 
 // HandleKeystore ...
@@ -61,12 +72,48 @@ func keystoreToJSON(data []byte, password, alias, keyPassword string) (string, e
 	}
 
 	certModel := convertCertificateInformation(certInfo)
+
+	// The file SHA-256 is always computable from the uploaded bytes.
+	fileSHA256 := sha256Hex(data)
+	certModel.FileSHA256 = &fileSHA256
+
+	// The certificate fingerprint is best effort: ReadCertificateInformation does not expose the
+	// raw certificate, so we decode it again to compute the fingerprint. Decoding already succeeded
+	// above, so this should succeed too; if it does not, the fingerprint is left null.
+	if cert, err := keystoreSigningCertificate(data, password, alias, keyPassword); err == nil {
+		fingerprint := sha256Fingerprint(cert)
+		certModel.CertificateSHA256Fingerprint = &fingerprint
+	}
+
 	b, err := json.Marshal(certModel)
 	if err != nil {
 		return "", err
 	}
 
 	return string(b), nil
+}
+
+// keystoreSigningCertificate decodes the keystore and returns the signing certificate.
+// It mirrors the decoders used by keystore.NewDefaultReader.
+func keystoreSigningCertificate(data []byte, password, alias, keyPassword string) (*x509.Certificate, error) {
+	decoders := []keystore.Decoder{keystore.PKCS12KeystoreDecoder{}, keystore.JKSKeystoreDecoder{}}
+	for _, decoder := range decoders {
+		if _, cert, err := decoder.Decode(data, password, alias, keyPassword); err == nil && cert != nil {
+			return cert, nil
+		}
+	}
+	return nil, fmt.Errorf("could not decode certificate from keystore")
+}
+
+// sha256Fingerprint returns the SHA-256 fingerprint of the certificate in keytool format:
+// uppercase hex, colon-separated (e.g. "AB:CD:EF:...").
+func sha256Fingerprint(cert *x509.Certificate) string {
+	sum := sha256.Sum256(cert.Raw)
+	parts := make([]string, len(sum))
+	for i, b := range sum {
+		parts[i] = fmt.Sprintf("%02X", b)
+	}
+	return strings.Join(parts, ":")
 }
 
 func convertCertificateInformation(certInfo *keystore.CertificateInformation) CertificateInformation {

--- a/keystore_test.go
+++ b/keystore_test.go
@@ -2,12 +2,16 @@ package main
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	log "github.com/sirupsen/logrus"
@@ -82,9 +86,78 @@ func Test_handleKeystore(t *testing.T) {
 
 			data, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
-			require.Equal(t, tt.expectedResp, string(data))
+
+			if resp.StatusCode != http.StatusOK {
+				// Error responses are returned verbatim and are unaffected by the new fields.
+				require.Equal(t, tt.expectedResp, string(data))
+				return
+			}
+
+			var got, want CertificateInformation
+			require.NoError(t, json.Unmarshal(data, &got))
+			require.NoError(t, json.Unmarshal([]byte(tt.expectedResp), &want))
+
+			// The new fields are always present in a successful response.
+			require.NotNil(t, got.FileSHA256)
+			require.Regexp(t, `^[0-9a-f]{64}$`, *got.FileSHA256)
+			require.NotNil(t, got.CertificateSHA256Fingerprint)
+			require.Regexp(t, `^([0-9A-F]{2}:){31}[0-9A-F]{2}$`, *got.CertificateSHA256Fingerprint)
+
+			// All previously existing fields must be unchanged. `want` is decoded from the
+			// pre-existing expected JSON (which has no new fields), so comparing after clearing
+			// the new fields verifies the existing behavior is intact.
+			got.FileSHA256 = nil
+			got.CertificateSHA256Fingerprint = nil
+			require.Equal(t, want, got)
 		})
 	}
+}
+
+func Test_keystoreContentMetadata(t *testing.T) {
+	const (
+		fileName    = "debug.keystore"
+		pass        = "android"
+		alias       = "androiddebugkey"
+		keyPassword = "android"
+	)
+
+	fileBytes, err := os.ReadFile(filepath.Join("testdata", "keystores", fileName))
+	require.NoError(t, err)
+
+	r := httptest.NewRequest(http.MethodPost, "/keystore", bytes.NewReader(createRequestData(t, fileName, pass, alias, keyPassword)))
+	w := httptest.NewRecorder()
+
+	s := Service{Logger: log.New()}
+	s.HandleKeystore(w, r)
+
+	resp := w.Result()
+	defer func() {
+		require.NoError(t, resp.Body.Close())
+	}()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	data, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var got CertificateInformation
+	require.NoError(t, json.Unmarshal(data, &got))
+
+	// file_sha256 is the lowercase hex SHA-256 of the uploaded file bytes.
+	fileSum := sha256.Sum256(fileBytes)
+	require.NotNil(t, got.FileSHA256)
+	require.Equal(t, hex.EncodeToString(fileSum[:]), *got.FileSHA256)
+
+	// certificate_sha256_fingerprint is the signing cert's SHA-256 in keytool format
+	// (uppercase, colon-separated hex).
+	cert, err := keystoreSigningCertificate(fileBytes, pass, alias, keyPassword)
+	require.NoError(t, err)
+	certSum := sha256.Sum256(cert.Raw)
+	expectedParts := make([]string, len(certSum))
+	for i, b := range certSum {
+		expectedParts[i] = fmt.Sprintf("%02X", b)
+	}
+	require.NotNil(t, got.CertificateSHA256Fingerprint)
+	require.Equal(t, strings.Join(expectedParts, ":"), *got.CertificateSHA256Fingerprint)
 }
 
 func createRequestData(t *testing.T, testFileName string, pass, alias, keyPass string) []byte {

--- a/profile.go
+++ b/profile.go
@@ -52,11 +52,6 @@ type ProvisioningProfileInfoModel struct {
 	Entitlements          plistutil.PlistData    `json:"Entitlements,omitempty"`
 	ExpirationDate        time.Time              `json:"ExpirationDate"`
 
-	// ProfileUUID is the provisioning profile UUID. It is null when the UUID cannot be determined.
-	ProfileUUID *string `json:"uuid"`
-	// ExpiryDate is the profile ExpirationDate in RFC 3339 / ISO 8601 UTC.
-	// It is null when the expiry date cannot be determined.
-	ExpiryDate *time.Time `json:"expiry_date"`
 	// FileSHA256 is the SHA-256 of the uploaded file bytes as lowercase hex.
 	FileSHA256 *string `json:"file_sha256"`
 }
@@ -119,7 +114,7 @@ func (s Service) profileToProfileModel(profile profileutil.ProvisioningProfileIn
 		}
 	}
 
-	model := ProvisioningProfileInfoModel{
+	return ProvisioningProfileInfoModel{
 		UUID:                  profile.UUID,
 		Name:                  profile.Name,
 		TeamName:              profile.TeamName,
@@ -134,16 +129,4 @@ func (s Service) profileToProfileModel(profile profileutil.ProvisioningProfileIn
 		ExpirationDate:        profile.ExpirationDate,
 		FileSHA256:            fileSHA256,
 	}
-
-	if profile.UUID != "" {
-		uuid := profile.UUID
-		model.ProfileUUID = &uuid
-	}
-
-	if !profile.ExpirationDate.IsZero() {
-		expiry := profile.ExpirationDate.UTC()
-		model.ExpiryDate = &expiry
-	}
-
-	return model
 }

--- a/profile.go
+++ b/profile.go
@@ -51,6 +51,14 @@ type ProvisioningProfileInfoModel struct {
 	DeveloperCertificates []CertificateInfoModel `json:"DeveloperCertificates,omitempty"`
 	Entitlements          plistutil.PlistData    `json:"Entitlements,omitempty"`
 	ExpirationDate        time.Time              `json:"ExpirationDate"`
+
+	// ProfileUUID is the provisioning profile UUID. It is null when the UUID cannot be determined.
+	ProfileUUID *string `json:"uuid"`
+	// ExpiryDate is the profile ExpirationDate in RFC 3339 / ISO 8601 UTC.
+	// It is null when the expiry date cannot be determined.
+	ExpiryDate *time.Time `json:"expiry_date"`
+	// FileSHA256 is the SHA-256 of the uploaded file bytes as lowercase hex.
+	FileSHA256 *string `json:"file_sha256"`
 }
 
 // HandleProfile ...
@@ -84,7 +92,8 @@ func (s Service) profileToJSON(data []byte) (string, error) {
 		return "", err
 	}
 
-	profileModel := s.profileToProfileModel(profile)
+	fileSHA256 := sha256Hex(data)
+	profileModel := s.profileToProfileModel(profile, &fileSHA256)
 	b, err := json.Marshal(profileModel)
 	if err != nil {
 		return "", err
@@ -93,7 +102,9 @@ func (s Service) profileToJSON(data []byte) (string, error) {
 	return string(b), nil
 }
 
-func (s Service) profileToProfileModel(profile profileutil.ProvisioningProfileInfoModel) ProvisioningProfileInfoModel {
+// profileToProfileModel maps the parsed provisioning profile to a response model.
+// fileSHA256 is the SHA-256 of the uploaded profile file; pass nil when it is not available.
+func (s Service) profileToProfileModel(profile profileutil.ProvisioningProfileInfoModel, fileSHA256 *string) ProvisioningProfileInfoModel {
 	listingType := UnknownProfileListingType
 	listingPlatform := UnknownListingPlatform
 
@@ -108,7 +119,7 @@ func (s Service) profileToProfileModel(profile profileutil.ProvisioningProfileIn
 		}
 	}
 
-	return ProvisioningProfileInfoModel{
+	model := ProvisioningProfileInfoModel{
 		UUID:                  profile.UUID,
 		Name:                  profile.Name,
 		TeamName:              profile.TeamName,
@@ -118,8 +129,21 @@ func (s Service) profileToProfileModel(profile profileutil.ProvisioningProfileIn
 		ListingType:           listingType,
 		ListingPlatform:       listingPlatform,
 		ProvisionedDevices:    profile.ProvisionedDevices,
-		DeveloperCertificates: s.certsToCertModels(profile.DeveloperCertificates),
+		DeveloperCertificates: s.certsToCertModels(profile.DeveloperCertificates, nil),
 		Entitlements:          profile.Entitlements,
 		ExpirationDate:        profile.ExpirationDate,
+		FileSHA256:            fileSHA256,
 	}
+
+	if profile.UUID != "" {
+		uuid := profile.UUID
+		model.ProfileUUID = &uuid
+	}
+
+	if !profile.ExpirationDate.IsZero() {
+		expiry := profile.ExpirationDate.UTC()
+		model.ExpiryDate = &expiry
+	}
+
+	return model
 }

--- a/profile_test.go
+++ b/profile_test.go
@@ -120,9 +120,41 @@ func TestProfileInfoModel(t *testing.T) {
 			require.NotNil(t, profile)
 
 			s := Service{Logger: log.New()}
-			infoModel := s.profileToProfileModel(profile)
+			infoModel := s.profileToProfileModel(profile, nil)
 			require.Equal(t, tt.wantType, infoModel.ListingType)
 			require.Equal(t, tt.wantPlatform, infoModel.ListingPlatform)
 		})
 	}
+}
+
+func Test_profileToProfileModel_contentMetadata(t *testing.T) {
+	f, err := os.Open(filepath.Join("testdata", "profiles", "iOS_App_Development.plist"))
+	require.NoError(t, err)
+
+	b, err := io.ReadAll(f)
+	require.NoError(t, err)
+
+	pkcs7Profile := pkcs7.PKCS7{}
+	pkcs7Profile.Content = b
+
+	profile, err := profileutil.NewProvisioningProfileInfo(pkcs7Profile)
+	require.NoError(t, err)
+
+	fileHash := "0123456789abcdef"
+	s := Service{Logger: log.New()}
+	model := s.profileToProfileModel(profile, &fileHash)
+
+	require.NotNil(t, model.ProfileUUID)
+	require.Equal(t, profile.UUID, *model.ProfileUUID)
+	require.NotEmpty(t, *model.ProfileUUID)
+
+	require.NotNil(t, model.ExpiryDate)
+	require.Equal(t, profile.ExpirationDate.UTC(), *model.ExpiryDate)
+
+	require.NotNil(t, model.FileSHA256)
+	require.Equal(t, fileHash, *model.FileSHA256)
+
+	// Existing fields are preserved.
+	require.Equal(t, profile.UUID, model.UUID)
+	require.Equal(t, profile.ExpirationDate, model.ExpirationDate)
 }

--- a/profile_test.go
+++ b/profile_test.go
@@ -127,7 +127,7 @@ func TestProfileInfoModel(t *testing.T) {
 	}
 }
 
-func Test_profileToProfileModel_contentMetadata(t *testing.T) {
+func Test_profileToProfileModel_fileSHA256(t *testing.T) {
 	f, err := os.Open(filepath.Join("testdata", "profiles", "iOS_App_Development.plist"))
 	require.NoError(t, err)
 
@@ -144,17 +144,12 @@ func Test_profileToProfileModel_contentMetadata(t *testing.T) {
 	s := Service{Logger: log.New()}
 	model := s.profileToProfileModel(profile, &fileHash)
 
-	require.NotNil(t, model.ProfileUUID)
-	require.Equal(t, profile.UUID, *model.ProfileUUID)
-	require.NotEmpty(t, *model.ProfileUUID)
-
-	require.NotNil(t, model.ExpiryDate)
-	require.Equal(t, profile.ExpirationDate.UTC(), *model.ExpiryDate)
-
 	require.NotNil(t, model.FileSHA256)
 	require.Equal(t, fileHash, *model.FileSHA256)
 
-	// Existing fields are preserved.
+	// The existing UUID and ExpirationDate fields are preserved unchanged; consumers read those
+	// directly instead of duplicated fields.
+	require.NotEmpty(t, model.UUID)
 	require.Equal(t, profile.UUID, model.UUID)
 	require.Equal(t, profile.ExpirationDate, model.ExpirationDate)
 }

--- a/utils.go
+++ b/utils.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -53,4 +55,10 @@ func getRequestModel(r *http.Request) (RequestModel, error) {
 func isValidURL(reqURL string) bool {
 	_, err := url.ParseRequestURI(reqURL)
 	return err == nil
+}
+
+// sha256Hex returns the SHA-256 of the given bytes as a lowercase hex string.
+func sha256Hex(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
 }


### PR DESCRIPTION
Extends the `/certificate`, `/profile`, and `/keystore` endpoints with additional nullable metadata fields computed from the uploaded file bytes. All existing fields, JSON names, and error responses are unchanged; new fields are emitted as explicit JSON `null` when not computable, and `file_sha256` is always populated on the success path.

## New fields

### `/certificate` (`.p12`) — response is a JSON array; this field is added to each element:
| Field | Type | Description |
|---|---|---|
| `file_sha256` | `string\|null` | SHA-256 of the uploaded file bytes, lowercase hex |

### `/profile` (`.mobileprovision`):
| Field | Type | Description |
|---|---|---|
| `file_sha256` | `string\|null` | SHA-256 of the uploaded file bytes, lowercase hex |

### `/keystore`:
| Field | Type | Description |
|---|---|---|
| `certificate_sha256_fingerprint` | `string\|null` | Signing certificate SHA-256 in keytool format: uppercase hex, colon-separated (e.g. `"7D:98:00:11:..."`) |
| `file_sha256` | `string\|null` | SHA-256 of the uploaded file bytes, lowercase hex |

## Notes

- An earlier revision of this PR also added `certificate_serial`/`certificate_expiry_date` (on `/certificate`) and `uuid`/`expiry_date` (on `/profile`). These were removed after review: they duplicated existing response fields (`Serial`, `EndDate`, `UUID`, `ExpirationDate`) with no real transformation — `EndDate`/`ExpirationDate` are already RFC 3339 UTC, and the hex-vs-decimal serial conversion is now expected to happen on the consuming side. Only genuinely new, non-derivable fields remain in this PR.
- Existing fields (including `Serial`, `EndDate`, `UUID`, `ExpirationDate`) are preserved unchanged for backward compatibility.
- `file_sha256` is computed per-array-element for `/certificate` (no envelope wrapper added).
- The keystore signing certificate is decoded a second time (best-effort, documented in code) to compute the fingerprint, since the existing reader does not expose the raw certificate and the vendored dependency can't be modified here. The proper fix belongs upstream in `go-android`.
- Endpoint error behavior (e.g. wrong password → 400) is intentionally unchanged; new fields appear only in successful responses.

## Testing

- Unit tests added for each endpoint's new field(s).
- `go build`, `go vet`, `gofmt` all clean.
- All new and existing unit tests pass.
- The pre-existing `TestEndpoints` integration test requires env vars and live fixtures; it fails at baseline and is unaffected by this change.

## Companion PRs

- `bitrise-website`: https://github.com/bitrise-io/bitrise-website/pull/20030
- `bitrise-api`: https://github.com/bitrise-io/bitrise-api/pull/1158